### PR TITLE
perject-tab-make: Create new window objects

### DIFF
--- a/perject-tab.el
+++ b/perject-tab.el
@@ -660,7 +660,11 @@ nil. In the latter case, it defaults to the selected frame."
 							 perject-tab-extra-data))
 				 (mapcar (lambda (data) (cons (car data) (funcall (cdr data))))
 						 perject-tab-extra-data)))))
-	(append (tab-bar--tab frame) extra-data)))
+	(with-selected-frame (or frame (selected-frame))
+	  (save-window-excursion
+		;; Create new window objects to avoid interferences between different tabs.
+		(window-state-put (window-state-get))
+		(append (tab-bar--tab frame) extra-data)))))
 
 (defun perject-tab-collection-tabs (name)
   "Return the list of all tabs belonging to the collection named NAME.


### PR DESCRIPTION
Previously, after creating two distinct tabs from the same window configuration, both tabs would share identical window objects. This means in particular that the window's buffer histories (returned by `window-prev-buffers` and `window-next-buffers`) are shared between the two tabs. I would assume that this is not intended, as switching to different buffers in one tab should probably not interfere with future results of `previous-buffer` and `next-buffer` commands in the other tab? Though I understand this could actually also be a feature, but in that case perhaps it could be documented and/or configurable?

The same trick of calling `(window-state-put (window-state-get))` is also used in tab-bar.el in the function `tab-bar-new-tab-to`, intended to avoid the same kinds of interferences between tabs.

(Thanks for this hidden gem of a package, by the way, it works very well for me and seems well written. I also really appreciate the thorough documentation, which makes reading the code a pleasure.)